### PR TITLE
[FINAL] Dispatch the whole identify event to the main thread, not just the user change.

### DIFF
--- a/Pod/Classes/SEGAppboyIntegration.m
+++ b/Pod/Classes/SEGAppboyIntegration.m
@@ -56,105 +56,101 @@
 
 - (void)identify:(SEGIdentifyPayload *)payload
 {
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self identify:payload];
+    });
+    return;
+  }
+
   // Ensure that the userID is set and valid (i.e. a non-empty string).
   if (payload.userId != nil && [payload.userId length] != 0) {
-    // `changeUser:` should always be called in the main thread. If we are already in the main thread,
-    // calling dispatch_sync will cause hanging.
-    if ([NSThread isMainThread]) {
-      [[Appboy sharedInstance] changeUser:payload.userId];
-      SEGLog(@"[[Appboy sharedInstance] changeUser:%@]", payload.userId);
-    } else {
-      // Note: this must be async because segmentio synchronizes in forwardSelector - if identify is called from a different thread
-      // and then forwardSelector is called, we can get into deadlock where the forwardSelector on the main thread is waiting
-      // for the SEGAnalytics class lock and a separate call has it and is waiting here for the main thread.
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [[Appboy sharedInstance] changeUser:payload.userId];
-        SEGLog(@"[[Appboy sharedInstance] changeUser:%@]", payload.userId);
-      });
+    [[Appboy sharedInstance] changeUser:payload.userId];
+    SEGLog(@"[[Appboy sharedInstance] changeUser:%@]", payload.userId);
+
+    if ([payload.traits[@"birthday"] isKindOfClass:[NSString class]]) {
+      NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+      NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+      [dateFormatter setLocale:enUSPOSIXLocale];
+      [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
+      [Appboy sharedInstance].user.dateOfBirth = [dateFormatter dateFromString:payload.traits[@"birthday"]];
+      SEGLog(@"Logged [Appboy sharedInstance].user.dateOfBirth");
     }
-  }
-  
-  if ([payload.traits[@"birthday"] isKindOfClass:[NSString class]]) {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-    [dateFormatter setLocale:enUSPOSIXLocale];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
-    [Appboy sharedInstance].user.dateOfBirth = [dateFormatter dateFromString:payload.traits[@"birthday"]];
-    SEGLog(@"Logged [Appboy sharedInstance].user.dateOfBirth");
-  }
-  
-  if ([payload.traits[@"email"] isKindOfClass:[NSString class]]) {
-    [Appboy sharedInstance].user.email = payload.traits[@"email"];
-    SEGLog(@"Logged [Appboy sharedInstance].user.email");
-  }
-  
-  if ([payload.traits[@"firstName"] isKindOfClass:[NSString class]]) {
-    [Appboy sharedInstance].user.firstName = payload.traits[@"firstName"];
-    SEGLog(@"Logged [Appboy sharedInstance].user.firstName");
-  }
-  
-  if ([payload.traits[@"lastName"] isKindOfClass:[NSString class]]) {
-    [Appboy sharedInstance].user.lastName = payload.traits[@"lastName"];
-    SEGLog(@"Logged [Appboy sharedInstance].user.lastName");
-  }
-  
-  // Appboy only accepts "m" or "male" for gender male, and "f" or "female" for gender female, with case insensitive.
-  if ([payload.traits[@"gender"] isKindOfClass:[NSString class]]) {
-    NSString *gender = payload.traits[@"gender"];
-    if ([gender.lowercaseString isEqualToString:@"m"] || [gender.lowercaseString isEqualToString:@"male"]) {
-      [[Appboy sharedInstance].user setGender:ABKUserGenderMale];
-      SEGLog(@"[[Appboy sharedInstance].user setGender:]");
-    } else if ([gender.lowercaseString isEqualToString:@"f"] || [gender.lowercaseString isEqualToString:@"female"]) {
-      [[Appboy sharedInstance].user setGender:ABKUserGenderFemale];
-      SEGLog(@"[[Appboy sharedInstance].user setGender:]");
+
+    if ([payload.traits[@"email"] isKindOfClass:[NSString class]]) {
+      [Appboy sharedInstance].user.email = payload.traits[@"email"];
+      SEGLog(@"Logged [Appboy sharedInstance].user.email");
     }
-  }
-  
-  if ([payload.traits[@"phone"] isKindOfClass:[NSString class]]) {
-    [Appboy sharedInstance].user.phone = payload.traits[@"phone"];
-    SEGLog(@"Logged [Appboy sharedInstance].user.phone");
-  }
-  
-  if ([payload.traits[@"address"] isKindOfClass:[NSDictionary class]]) {
-    NSDictionary *address = payload.traits[@"address"];
-    if ([address[@"city"] isKindOfClass:[NSString class]]) {
-      [Appboy sharedInstance].user.homeCity = address[@"city"];
-      SEGLog(@"Logged [Appboy sharedInstance].user.homeCity");
+
+    if ([payload.traits[@"firstName"] isKindOfClass:[NSString class]]) {
+      [Appboy sharedInstance].user.firstName = payload.traits[@"firstName"];
+      SEGLog(@"Logged [Appboy sharedInstance].user.firstName");
     }
-    
-    if ([address[@"country"] isKindOfClass:[NSString class]]) {
-      [Appboy sharedInstance].user.country = address[@"country"];
-      SEGLog(@"Logged [Appboy sharedInstance].user.country");
+
+    if ([payload.traits[@"lastName"] isKindOfClass:[NSString class]]) {
+      [Appboy sharedInstance].user.lastName = payload.traits[@"lastName"];
+      SEGLog(@"Logged [Appboy sharedInstance].user.lastName");
     }
-  }
-  
-  NSArray *appboyTraits = @[@"birthday", @"email", @"firstName", @"lastName",  @"gender", @"phone", @"address", @"anonymousID"];
-  
-  // Other traits. Iterate over all the traits and set them.
-  for (NSString *key in payload.traits.allKeys) {
-    if (![appboyTraits containsObject:key]) {
-      id traitValue = payload.traits[key];
-      if ([traitValue isKindOfClass:[NSString class]]) {
-      [[Appboy sharedInstance].user setCustomAttributeWithKey:key andStringValue:traitValue];
-        SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andStringValue:]");
-      } else if ([traitValue isKindOfClass:[NSNumber class]]) {
-        if (strcmp([traitValue objCType], [@(YES) objCType]) == 0) {
-          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andBOOLValue:[(NSNumber *)traitValue boolValue]];
-          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andBOOLValue:]");
-        } else if (strcmp([traitValue objCType], @encode(short)) == 0 ||
-                   strcmp([traitValue objCType], @encode(int)) == 0 ||
-                   strcmp([traitValue objCType], @encode(long)) == 0) {
-          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andIntegerValue:[(NSNumber *)traitValue integerValue]];
-          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andIntegerValue:]");
-        } else if (strcmp([traitValue objCType], @encode(float)) == 0 ||
-                   strcmp([traitValue objCType], @encode(double)) == 0) {
-          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andDoubleValue:[(NSNumber *)traitValue doubleValue]];
-          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andDoubleValue:]");
-        } else {
-          SEGLog(@"Could not map NSNumber value to Appboy custom attribute:%@]", traitValue);
+
+    // Appboy only accepts "m" or "male" for gender male, and "f" or "female" for gender female, with case insensitive.
+    if ([payload.traits[@"gender"] isKindOfClass:[NSString class]]) {
+      NSString *gender = payload.traits[@"gender"];
+      if ([gender.lowercaseString isEqualToString:@"m"] || [gender.lowercaseString isEqualToString:@"male"]) {
+        [[Appboy sharedInstance].user setGender:ABKUserGenderMale];
+        SEGLog(@"[[Appboy sharedInstance].user setGender:]");
+      } else if ([gender.lowercaseString isEqualToString:@"f"] || [gender.lowercaseString isEqualToString:@"female"]) {
+        [[Appboy sharedInstance].user setGender:ABKUserGenderFemale];
+        SEGLog(@"[[Appboy sharedInstance].user setGender:]");
+      }
+    }
+
+    if ([payload.traits[@"phone"] isKindOfClass:[NSString class]]) {
+      [Appboy sharedInstance].user.phone = payload.traits[@"phone"];
+      SEGLog(@"Logged [Appboy sharedInstance].user.phone");
+    }
+
+    if ([payload.traits[@"address"] isKindOfClass:[NSDictionary class]]) {
+      NSDictionary *address = payload.traits[@"address"];
+      if ([address[@"city"] isKindOfClass:[NSString class]]) {
+        [Appboy sharedInstance].user.homeCity = address[@"city"];
+        SEGLog(@"Logged [Appboy sharedInstance].user.homeCity");
+      }
+
+      if ([address[@"country"] isKindOfClass:[NSString class]]) {
+        [Appboy sharedInstance].user.country = address[@"country"];
+        SEGLog(@"Logged [Appboy sharedInstance].user.country");
+      }
+    }
+
+    NSArray *appboyTraits = @[@"birthday", @"email", @"firstName", @"lastName",  @"gender", @"phone", @"address", @"anonymousID"];
+
+    // Other traits. Iterate over all the traits and set them.
+    for (NSString *key in payload.traits.allKeys) {
+      if (![appboyTraits containsObject:key]) {
+        id traitValue = payload.traits[key];
+        if ([traitValue isKindOfClass:[NSString class]]) {
+          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andStringValue:traitValue];
+          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andStringValue:]");
+        } else if ([traitValue isKindOfClass:[NSNumber class]]) {
+          if (strcmp([traitValue objCType], [@(YES) objCType]) == 0) {
+            [[Appboy sharedInstance].user setCustomAttributeWithKey:key andBOOLValue:[(NSNumber *)traitValue boolValue]];
+            SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andBOOLValue:]");
+          } else if (strcmp([traitValue objCType], @encode(short)) == 0 ||
+                     strcmp([traitValue objCType], @encode(int)) == 0 ||
+                     strcmp([traitValue objCType], @encode(long)) == 0) {
+            [[Appboy sharedInstance].user setCustomAttributeWithKey:key andIntegerValue:[(NSNumber *)traitValue integerValue]];
+            SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andIntegerValue:]");
+          } else if (strcmp([traitValue objCType], @encode(float)) == 0 ||
+                     strcmp([traitValue objCType], @encode(double)) == 0) {
+            [[Appboy sharedInstance].user setCustomAttributeWithKey:key andDoubleValue:[(NSNumber *)traitValue doubleValue]];
+            SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andDoubleValue:]");
+          } else {
+            SEGLog(@"Could not map NSNumber value to Appboy custom attribute:%@]", traitValue);
+          }
         }
       }
     }
+    
   }
 }
 

--- a/Pod/Classes/SEGAppboyIntegration.m
+++ b/Pod/Classes/SEGAppboyIntegration.m
@@ -67,90 +67,89 @@
   if (payload.userId != nil && [payload.userId length] != 0) {
     [[Appboy sharedInstance] changeUser:payload.userId];
     SEGLog(@"[[Appboy sharedInstance] changeUser:%@]", payload.userId);
+  }
 
-    if ([payload.traits[@"birthday"] isKindOfClass:[NSString class]]) {
-      NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-      NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-      [dateFormatter setLocale:enUSPOSIXLocale];
-      [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
-      [Appboy sharedInstance].user.dateOfBirth = [dateFormatter dateFromString:payload.traits[@"birthday"]];
-      SEGLog(@"Logged [Appboy sharedInstance].user.dateOfBirth");
+  if ([payload.traits[@"birthday"] isKindOfClass:[NSString class]]) {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    [dateFormatter setLocale:enUSPOSIXLocale];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
+    [Appboy sharedInstance].user.dateOfBirth = [dateFormatter dateFromString:payload.traits[@"birthday"]];
+    SEGLog(@"Logged [Appboy sharedInstance].user.dateOfBirth");
+  }
+
+  if ([payload.traits[@"email"] isKindOfClass:[NSString class]]) {
+    [Appboy sharedInstance].user.email = payload.traits[@"email"];
+    SEGLog(@"Logged [Appboy sharedInstance].user.email");
+  }
+
+  if ([payload.traits[@"firstName"] isKindOfClass:[NSString class]]) {
+    [Appboy sharedInstance].user.firstName = payload.traits[@"firstName"];
+    SEGLog(@"Logged [Appboy sharedInstance].user.firstName");
+  }
+
+  if ([payload.traits[@"lastName"] isKindOfClass:[NSString class]]) {
+    [Appboy sharedInstance].user.lastName = payload.traits[@"lastName"];
+    SEGLog(@"Logged [Appboy sharedInstance].user.lastName");
+  }
+
+  // Appboy only accepts "m" or "male" for gender male, and "f" or "female" for gender female, with case insensitive.
+  if ([payload.traits[@"gender"] isKindOfClass:[NSString class]]) {
+    NSString *gender = payload.traits[@"gender"];
+    if ([gender.lowercaseString isEqualToString:@"m"] || [gender.lowercaseString isEqualToString:@"male"]) {
+      [[Appboy sharedInstance].user setGender:ABKUserGenderMale];
+      SEGLog(@"[[Appboy sharedInstance].user setGender:]");
+    } else if ([gender.lowercaseString isEqualToString:@"f"] || [gender.lowercaseString isEqualToString:@"female"]) {
+      [[Appboy sharedInstance].user setGender:ABKUserGenderFemale];
+      SEGLog(@"[[Appboy sharedInstance].user setGender:]");
+    }
+  }
+
+  if ([payload.traits[@"phone"] isKindOfClass:[NSString class]]) {
+    [Appboy sharedInstance].user.phone = payload.traits[@"phone"];
+    SEGLog(@"Logged [Appboy sharedInstance].user.phone");
+  }
+
+  if ([payload.traits[@"address"] isKindOfClass:[NSDictionary class]]) {
+    NSDictionary *address = payload.traits[@"address"];
+    if ([address[@"city"] isKindOfClass:[NSString class]]) {
+      [Appboy sharedInstance].user.homeCity = address[@"city"];
+      SEGLog(@"Logged [Appboy sharedInstance].user.homeCity");
     }
 
-    if ([payload.traits[@"email"] isKindOfClass:[NSString class]]) {
-      [Appboy sharedInstance].user.email = payload.traits[@"email"];
-      SEGLog(@"Logged [Appboy sharedInstance].user.email");
+    if ([address[@"country"] isKindOfClass:[NSString class]]) {
+      [Appboy sharedInstance].user.country = address[@"country"];
+      SEGLog(@"Logged [Appboy sharedInstance].user.country");
     }
+  }
 
-    if ([payload.traits[@"firstName"] isKindOfClass:[NSString class]]) {
-      [Appboy sharedInstance].user.firstName = payload.traits[@"firstName"];
-      SEGLog(@"Logged [Appboy sharedInstance].user.firstName");
-    }
+  NSArray *appboyTraits = @[@"birthday", @"email", @"firstName", @"lastName",  @"gender", @"phone", @"address", @"anonymousID"];
 
-    if ([payload.traits[@"lastName"] isKindOfClass:[NSString class]]) {
-      [Appboy sharedInstance].user.lastName = payload.traits[@"lastName"];
-      SEGLog(@"Logged [Appboy sharedInstance].user.lastName");
-    }
-
-    // Appboy only accepts "m" or "male" for gender male, and "f" or "female" for gender female, with case insensitive.
-    if ([payload.traits[@"gender"] isKindOfClass:[NSString class]]) {
-      NSString *gender = payload.traits[@"gender"];
-      if ([gender.lowercaseString isEqualToString:@"m"] || [gender.lowercaseString isEqualToString:@"male"]) {
-        [[Appboy sharedInstance].user setGender:ABKUserGenderMale];
-        SEGLog(@"[[Appboy sharedInstance].user setGender:]");
-      } else if ([gender.lowercaseString isEqualToString:@"f"] || [gender.lowercaseString isEqualToString:@"female"]) {
-        [[Appboy sharedInstance].user setGender:ABKUserGenderFemale];
-        SEGLog(@"[[Appboy sharedInstance].user setGender:]");
-      }
-    }
-
-    if ([payload.traits[@"phone"] isKindOfClass:[NSString class]]) {
-      [Appboy sharedInstance].user.phone = payload.traits[@"phone"];
-      SEGLog(@"Logged [Appboy sharedInstance].user.phone");
-    }
-
-    if ([payload.traits[@"address"] isKindOfClass:[NSDictionary class]]) {
-      NSDictionary *address = payload.traits[@"address"];
-      if ([address[@"city"] isKindOfClass:[NSString class]]) {
-        [Appboy sharedInstance].user.homeCity = address[@"city"];
-        SEGLog(@"Logged [Appboy sharedInstance].user.homeCity");
-      }
-
-      if ([address[@"country"] isKindOfClass:[NSString class]]) {
-        [Appboy sharedInstance].user.country = address[@"country"];
-        SEGLog(@"Logged [Appboy sharedInstance].user.country");
-      }
-    }
-
-    NSArray *appboyTraits = @[@"birthday", @"email", @"firstName", @"lastName",  @"gender", @"phone", @"address", @"anonymousID"];
-
-    // Other traits. Iterate over all the traits and set them.
-    for (NSString *key in payload.traits.allKeys) {
-      if (![appboyTraits containsObject:key]) {
-        id traitValue = payload.traits[key];
-        if ([traitValue isKindOfClass:[NSString class]]) {
-          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andStringValue:traitValue];
-          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andStringValue:]");
-        } else if ([traitValue isKindOfClass:[NSNumber class]]) {
-          if (strcmp([traitValue objCType], [@(YES) objCType]) == 0) {
-            [[Appboy sharedInstance].user setCustomAttributeWithKey:key andBOOLValue:[(NSNumber *)traitValue boolValue]];
-            SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andBOOLValue:]");
-          } else if (strcmp([traitValue objCType], @encode(short)) == 0 ||
-                     strcmp([traitValue objCType], @encode(int)) == 0 ||
-                     strcmp([traitValue objCType], @encode(long)) == 0) {
-            [[Appboy sharedInstance].user setCustomAttributeWithKey:key andIntegerValue:[(NSNumber *)traitValue integerValue]];
-            SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andIntegerValue:]");
-          } else if (strcmp([traitValue objCType], @encode(float)) == 0 ||
-                     strcmp([traitValue objCType], @encode(double)) == 0) {
-            [[Appboy sharedInstance].user setCustomAttributeWithKey:key andDoubleValue:[(NSNumber *)traitValue doubleValue]];
-            SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andDoubleValue:]");
-          } else {
-            SEGLog(@"Could not map NSNumber value to Appboy custom attribute:%@]", traitValue);
-          }
+  // Other traits. Iterate over all the traits and set them.
+  for (NSString *key in payload.traits.allKeys) {
+    if (![appboyTraits containsObject:key]) {
+      id traitValue = payload.traits[key];
+      if ([traitValue isKindOfClass:[NSString class]]) {
+        [[Appboy sharedInstance].user setCustomAttributeWithKey:key andStringValue:traitValue];
+        SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andStringValue:]");
+      } else if ([traitValue isKindOfClass:[NSNumber class]]) {
+        if (strcmp([traitValue objCType], [@(YES) objCType]) == 0) {
+          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andBOOLValue:[(NSNumber *)traitValue boolValue]];
+          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andBOOLValue:]");
+        } else if (strcmp([traitValue objCType], @encode(short)) == 0 ||
+                   strcmp([traitValue objCType], @encode(int)) == 0 ||
+                   strcmp([traitValue objCType], @encode(long)) == 0) {
+          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andIntegerValue:[(NSNumber *)traitValue integerValue]];
+          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andIntegerValue:]");
+        } else if (strcmp([traitValue objCType], @encode(float)) == 0 ||
+                   strcmp([traitValue objCType], @encode(double)) == 0) {
+          [[Appboy sharedInstance].user setCustomAttributeWithKey:key andDoubleValue:[(NSNumber *)traitValue doubleValue]];
+          SEGLog(@"[[Appboy sharedInstance].user setCustomAttributeWithKey: andDoubleValue:]");
+        } else {
+          SEGLog(@"Could not map NSNumber value to Appboy custom attribute:%@]", traitValue);
         }
       }
     }
-    
   }
 }
 


### PR DESCRIPTION
This was causing a bug where a user wouldn't receive the traits they needed because their traits were being assigned to the previous user.
